### PR TITLE
Case insensitive entry types

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -741,7 +741,7 @@ func (p *parser) parseBibDecl() *ast.BibDecl {
 		defer un(trace(p, "BibDecl"))
 	}
 	doc := p.leadComment
-	entryType := p.lit[1:] // drop '@', e.g. "@book" -> "book"
+	entryType := strings.ToLower(p.lit[1:]) // drop '@', e.g. "@BOOK" -> "book"
 	pos := p.expect(token.BibEntry)
 	var bibKey *ast.Ident // use first key found as bibKey
 	var extraKeys []*ast.Ident

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -168,6 +168,12 @@ func TestParseFile_BibDecl_NoParseStrings(t *testing.T) {
 			asts.WithBibKeys("111", "a", "b"),
 			asts.WithBibTags("key", asts.Ident("bar"), "k2", asts.UnparsedText("v2")),
 		},
+		{
+			"@InProceedings {cite_key1, key = {foo} }",
+			asts.WithBibType("inproceedings"),
+			asts.WithBibKeys("cite_key1"),
+			asts.WithBibTags("key", asts.UnparsedBraceText("foo")),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.src, func(t *testing.T) {


### PR DESCRIPTION
Hi, thanks for the cool project

This small PR makes the parsing of the bibtex entry types case insensitive by always `strings.toLower` them. E.g. `@inproceedings` and `@InProceedings` and `@INPROCEEDINGS` are all equivalent.

This is not well-specified in this (very minimal) [bibtex format](https://www.bibtex.org/Format/) but seems to be [uncontroversial](https://tex.stackexchange.com/a/165760) and definitely how bibtex and biblatex parse it.

