### PR TITLE
Parse accent in author field

### DIFF
--- a/author.go
+++ b/author.go
@@ -7,6 +7,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/jschaf/bibtex/ast"
+	"github.com/jschaf/bibtex/render"
 )
 
 const authorSep = "and"
@@ -140,6 +141,12 @@ func parseDefault(idx int, xs []ast.Expr) string {
 		return "$" + t.Value + "$"
 	case *ast.Text:
 		return t.Value
+	case *ast.TextAccent:
+		r, err := render.RenderAccent(t.Accent, t.Text.Value)
+		if err != nil {
+			panic("cannot render accent")
+		}
+		return string(r)
 	default:
 		panic("unhandled ast.Expr value")
 	}

--- a/author.go
+++ b/author.go
@@ -83,14 +83,18 @@ const (
 
 func parseFirstName(idx int, xs []ast.Expr) (string, resolveAction) {
 	x := xs[idx]
+	if _, ok := x.(*ast.TextSpace); ok && idx < len(xs)-1 {
+		if t, ok := xs[idx+1].(*ast.Text); ok && !hasUpperPrefix(t.Value) {
+			// lowercase after space means we're out of the first name
+			return "", resolveNextPart
+		}
+	}
+
 	if _, ok := x.(*ast.Text); !ok {
 		return parseDefault(idx, xs), resolveContinue
 	}
 
 	t := x.(*ast.Text)
-	if !hasUpperPrefix(t.Value) {
-		return "", resolveNextPart // lowercase means we're out of the first name
-	}
 
 	return t.Value, resolveContinue
 }

--- a/author_test.go
+++ b/author_test.go
@@ -23,6 +23,8 @@ func TestResolveAuthors_single(t *testing.T) {
 		{"{von Beethoven}, Ludwig", newAuthor("Ludwig", "von Beethoven")},
 		{"Jean-Paul Sartre", newAuthor("Jean-Paul", "Sartre")},
 		{"First von Last", newAuthor("First", "von", "Last")},
+		{"First von Last", newAuthor("First", "von", "Last")},
+		{"Beno{\\^i}t de Meg\\`eve", newAuthor("Benoît", "de", "Megève")},
 		{
 			"Charles Louis Xavier Joseph de la Vallee Poussin",
 			newAuthor("Charles Louis Xavier Joseph", "de la", "Vallee Poussin"),

--- a/render/accent.go
+++ b/render/accent.go
@@ -35,8 +35,8 @@ var accentMap = map[string]rune{
 	".C": 'Ċ', ".E": 'Ė', ".G": 'Ġ', ".I": 'İ', ".Z": 'Ż',
 }
 
-// fmtAccent renders an accented character.
-func fmtAccent(accent token.Accent, text string) (rune, error) {
+// RenderAccent renders an accented character.
+func RenderAccent(accent token.Accent, text string) (rune, error) {
 	if len(text) == 0 {
 		return 0, fmt.Errorf("cannot render accent %q for empty text", accent)
 	}

--- a/render/render.go
+++ b/render/render.go
@@ -2,8 +2,9 @@ package render
 
 import (
 	"fmt"
-	"github.com/jschaf/bibtex/ast"
 	"io"
+
+	"github.com/jschaf/bibtex/ast"
 )
 
 type NodeRenderer interface {
@@ -266,7 +267,7 @@ func (p TextRenderer) Render(w io.Writer, x ast.Expr) error {
 			return err
 		}
 	case *ast.TextAccent:
-		r, err := fmtAccent(t.Accent, t.Text.Value)
+		r, err := RenderAccent(t.Accent, t.Text.Value)
 		if err != nil {
 			return fmt.Errorf("render accent: %w", err)
 		}


### PR DESCRIPTION
#7 introduced support for `TextAccent` rendering. This works as expected for most bibtex fields, but the `author` field is parsed separately, resulting in a
```
panic: unhandled ast.Expr value
```
from `github.com/jschaf/bibtex.parseDefault`.

This PR fixes this by rendering accents within `ExtractAuthors` during parsing.