### PR TITLE
Fix implicit curly-brackets parsing for accents

### DIFF
--- a/author_test.go
+++ b/author_test.go
@@ -25,6 +25,9 @@ func TestResolveAuthors_single(t *testing.T) {
 		{"First von Last", newAuthor("First", "von", "Last")},
 		{"First von Last", newAuthor("First", "von", "Last")},
 		{"Beno{\\^i}t de Meg\\`eve", newAuthor("Benoît", "de", "Megève")},
+		{"Fran{\\c{c}}oise Chollet", newAuthor("Françoise", "Chollet")},
+		{"Fran{\\cc}oise Chollet", newAuthor("Françoise", "Chollet")},
+		{"Fran{\\c c}oise Chollet", newAuthor("Françoise", "Chollet")},
 		{
 			"Charles Louis Xavier Joseph de la Vallee Poussin",
 			newAuthor("Charles Louis Xavier Joseph", "de la", "Vallee Poussin"),

--- a/author_test.go
+++ b/author_test.go
@@ -28,6 +28,7 @@ func TestResolveAuthors_single(t *testing.T) {
 		{"Fran{\\c{c}}oise Chollet", newAuthor("Françoise", "Chollet")},
 		{"Fran{\\cc}oise Chollet", newAuthor("Françoise", "Chollet")},
 		{"Fran{\\c c}oise Chollet", newAuthor("Françoise", "Chollet")},
+		{"Fran{\\c    c}oise Chollet", newAuthor("Françoise", "Chollet")},
 		{
 			"Charles Louis Xavier Joseph de la Vallee Poussin",
 			newAuthor("Charles Louis Xavier Joseph", "de la", "Vallee Poussin"),

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -360,12 +360,15 @@ func (s *Scanner) scanSpecialCharStringAccent() (token.Token, string) {
 		s.next() // consume right brace
 	} else if s.ch == ' ' { // handle implicit braces like '\c c'
 		// Construct accent string e.g. '\c'
-		substring := string(s.src[offs:s.offset])
-		s.next() // consume space
+		tokStr := string(s.src[offs:s.offset])
+		// consume spaces until next valid char (like in {\c   c})
+		for s.ch == ' ' {
+			s.next()
+		}
 		// append accented char, e.g. 'c'
-		substring += string(s.src[s.offset])
+		tokStr += string(s.src[s.offset])
 		s.next() // consume the letter that's accented
-		return token.StringAccent, substring
+		return token.StringAccent, tokStr
 	} else {
 		if !IsAsciiLetter(s.ch) {
 			s.errorf(offs, "expected ascii letter after accent sequence %q , got %q", string(s.src[offs:s.offset-1]), s.ch)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -358,6 +358,14 @@ func (s *Scanner) scanSpecialCharStringAccent() (token.Token, string) {
 			return token.Illegal, ""
 		}
 		s.next() // consume right brace
+	} else if s.ch == ' ' { // handle implicit braces like '\c c'
+		// Construct accent string e.g. '\c'
+		substring := string(s.src[offs:s.offset])
+		s.next() // consume space
+		// append accented char, e.g. 'c'
+		substring += string(s.src[s.offset])
+		s.next() // consume the letter that's accented
+		return token.StringAccent, substring
 	} else {
 		if !IsAsciiLetter(s.ch) {
 			s.errorf(offs, "expected ascii letter after accent sequence %q , got %q", string(s.src[offs:s.offset-1]), s.ch)


### PR DESCRIPTION
#7 and #10 introduced support for parsing LaTeX accents in BibTex fields such as the `author` field. Under certain circumstances, such as using the Better BibTex plugin for Zotero, accents may appear with implicit curly braces that would otherwise be valid in LaTeX, but crash the parsing here. For example, `{\c c}` should be parsed the same as `{\c{c}}`. 

You can see this used as the example for cedilla [in this popular StackOverflow answer](https://tex.stackexchange.com/a/57745).

This PR adds support for parsing the case of implicit curly braces. I added tests, and the handling logic seems _sounds_, although it's not _elegant_.

Feel free to leave feedback on improving the logic flow as part of a code review! I can work in Go codebases, but I am not very skilled at it (yet) :)

Thanks!